### PR TITLE
get pandas from apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,19 @@ FROM python:3.9-slim-bullseye
 LABEL maintainer="Christopher Nethercott" \
     description="PiHole to InfluxDB data bridge"
 
+WORKDIR /app
+
 # Install Python packages
-COPY requirements.txt /
-RUN pip install -r /requirements.txt
+COPY requirements.txt .
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends python3-pandas && \
+  pip install -r requirements.txt
 
 # Clean up
-RUN apt-get -q -y autoremove
-RUN apt-get -q -y clean
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get -q -y autoremove && \
+  apt-get -q -y clean && \
+  rm -rf /var/lib/apt/lists/*
 
 # Final setup & execution
 COPY . /app
-WORKDIR /app
 CMD ["python3", "-u", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM debian:bullseye-slim
 
 LABEL maintainer="Christopher Nethercott" \
     description="PiHole to InfluxDB data bridge"
@@ -8,8 +8,8 @@ WORKDIR /app
 # Install Python packages
 COPY requirements.txt .
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends python3-pandas && \
-  pip install -r requirements.txt
+  apt-get install -y --no-install-recommends python3 python3-pip python3-pandas && \
+  python3 -m pip install -r requirements.txt
 
 # Clean up
 RUN apt-get -q -y autoremove && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 influxdb-client
-pandas
 requests


### PR DESCRIPTION
should fix #9.
Get `python3-pandas` from Debian apt.
Somehow `pip install -r requirements.txt` doesn't use prebuilt binaries, i don't know why.